### PR TITLE
consider relative paths

### DIFF
--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Management.Automation;
 using SevenZip;
 
@@ -46,7 +47,10 @@ namespace SevenZip4Powershell {
                     CompressionMethod = _cmdlet.CompressionMethod
                 };
 
-                var activity = String.Format("Compressing {0} to {1}", _cmdlet.Directory, _cmdlet.FileName);
+                var directory = Path.Combine(_cmdlet.SessionState.Path.CurrentFileSystemLocation.Path, _cmdlet.Directory);
+                var fileName = Path.Combine(_cmdlet.SessionState.Path.CurrentFileSystemLocation.Path, _cmdlet.FileName);
+
+                var activity = String.Format("Compressing {0} to {1}", directory, fileName);
                 var currentStatus = "Compressing";
                 compressor.FilesFound += (sender, args) =>
                     Write(String.Format("{0} files found for compression", args.Value));
@@ -57,7 +61,7 @@ namespace SevenZip4Powershell {
                     Write(String.Format("Compressing {0}", args.FileName));
                 };
 
-                compressor.CompressDirectory(_cmdlet.Directory, _cmdlet.FileName);
+                compressor.CompressDirectory(directory, fileName);
 
                 WriteProgress(new ProgressRecord(0, activity, "Finished") { RecordType = ProgressRecordType.Completed });
                 Write("Compression finished");

--- a/7Zip4Powershell/ThreadedCmdlet.cs
+++ b/7Zip4Powershell/ThreadedCmdlet.cs
@@ -4,7 +4,7 @@ using System.Management.Automation;
 using System.Threading;
 
 namespace SevenZip4Powershell {
-    public abstract class ThreadedCmdlet : Cmdlet {
+    public abstract class ThreadedCmdlet : PSCmdlet {
         protected abstract CmdletWorker CreateWorker();
         private Thread _thread;
 


### PR DESCRIPTION
With this change, the compress and expand CmdLets can work with relative
paths to the console's current working directory
