### PR TITLE
Added Get-7ZipInformation

### DIFF
--- a/7Zip4Powershell/7Zip4Powershell.csproj
+++ b/7Zip4Powershell/7Zip4Powershell.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Compress7Zip.cs" />
     <Compile Include="Expand7Zip.cs" />
     <Compile Include="Get7Zip.cs" />
+    <Compile Include="Get7ZipInformation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ThreadedCmdlet.cs" />
     <Compile Include="Utils.cs" />

--- a/7Zip4Powershell/7Zip4Powershell.psd1
+++ b/7Zip4Powershell/7Zip4Powershell.psd1
@@ -13,6 +13,7 @@ NestedModules = @("7Zip4PowerShell.dll")
 CmdletsToExport = @(
 	"Expand-7Zip",
 	"Compress-7Zip",
-	"Get-7Zip"
+	"Get-7Zip",
+	"Get-7ZipInformation"
 )
 }

--- a/7Zip4Powershell/Get7ZipInformation.cs
+++ b/7Zip4Powershell/Get7ZipInformation.cs
@@ -1,0 +1,60 @@
+﻿using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using JetBrains.Annotations;
+using SevenZip;
+
+namespace SevenZip4PowerShell {
+    [Cmdlet(VerbsCommon.Get, "7ZipInformation")]
+    [OutputType(typeof(ArchiveInformation))]
+    [PublicAPI]
+    public class Get7ZipInformation : PSCmdlet {
+        [Parameter(Position = 0, ValueFromPipeline = true, Mandatory = true, HelpMessage = "The full file name of the archive")]
+        [ValidateNotNullOrEmpty]
+        public string[] ArchiveFileName { get; set; }
+
+        [Parameter]
+        public string Password { get; set; }
+
+        protected override void BeginProcessing() {
+            SevenZipBase.SetLibraryPath(Utils.SevenZipLibraryPath);
+        }
+
+        protected override void ProcessRecord() {
+            foreach (var archiveFileName in ArchiveFileName.Select(_ => Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, _))) {
+                WriteVerbose($"Getting archive data {archiveFileName}");
+
+                SevenZipExtractor extractor;
+                if (!string.IsNullOrEmpty(Password)) {
+                    extractor = new SevenZipExtractor(archiveFileName, Password);
+                } else {
+                    extractor = new SevenZipExtractor(archiveFileName);
+                }
+
+                using (extractor) {
+                    extractor.Check();
+                    WriteObject(new ArchiveInformation {
+                        FileName = Path.GetFileName(archiveFileName),
+                        FullPath = Path.GetFullPath(archiveFileName),
+                        PackedSize = extractor.PackedSize,
+                        UnpackedSize = extractor.UnpackedSize,
+                        FilesCount = extractor.FilesCount,
+                        Format = extractor.Format,
+                        Method = extractor.ArchiveProperties.Where(prop => prop.Name == "Method").Cast<ArchiveProperty?>().FirstOrDefault()?.Value
+                    });
+                }
+            }
+        }
+    }
+
+    [PublicAPI]
+    public class ArchiveInformation {
+        public string FileName { get; set; }
+        public long PackedSize { get; set; }
+        public long UnpackedSize { get; set; }
+        public uint FilesCount { get; set; }
+        public string FullPath { get; set; }
+        public InArchiveFormat Format { get; set; }
+        public object Method { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Expand-7Zip
     [-Password <string>]
     [-CustomInitialization <ScriptBlock>]
     [<CommonParameters>]
- 
+
 Compress-7Zip
     [-ArchiveFileName] <string> 
     [-Path] <string> 
@@ -30,6 +30,11 @@ Compress-7Zip
 
 Get-7Zip
     [-ArchiveFileName] <string> 
+    [-Password <string>]
+    [<CommonParameters>]
+
+Get-7ZipInformation
+    [-ArchiveFileName] <string[]> 
     [-Password <string>]
     [<CommonParameters>]
 ```


### PR DESCRIPTION
The PR introduces the function `Get-7ZipInformation`, which returns information about the specified archive:
```
PS D:\demo> Get-7ZipInformation .\archive.7z


FileName     : archive.7z
PackedSize   : 135428158
UnpackedSize : 214221218
FilesCount   : 66
FullPath     : D:\demo\archive.7z
Format       : SevenZip
Method       : LZMA BCJ
```