### PR TITLE
Fix issues with post build targets for building Nuget package

### DIFF
--- a/7Zip4Powershell/PostBuild.targets
+++ b/7Zip4Powershell/PostBuild.targets
@@ -34,7 +34,7 @@
     <!-- create nuget package -->
     <Exec
       WorkingDirectory="$(SolutionDir)"
-      Command=".nuget\NuGet.exe pack 7Zip4Powershell.nuspec -tool -build -Properties Configuration=$(Configuration) -OutputDirectory $(OutDir) -Version $(GitVersion_MajorMinorPatch)"
+      Command=".nuget\NuGet.exe pack 7Zip4Powershell\7Zip4Powershell.nuspec -tool -build -Properties Configuration=$(Configuration) -OutputDirectory $(OutDir) -Version $(GitVersion_MajorMinorPatch)"
       />
   </Target>
 </Project>

--- a/7Zip4Powershell/PostBuild.targets
+++ b/7Zip4Powershell/PostBuild.targets
@@ -23,7 +23,7 @@
     </Task>
   </UsingTask>
 
-  <Target Name="CreateNugetPackage" AfterTargets="Build">
+  <Target Name="CreateNugetPackage" AfterTargets="Build" Condition="'$(GitVersion_MajorMinorPatch)' != ''">
     <!--patch module version in .psd1 -->
     <ReplaceFileText
       InputFilename="7Zip4PowerShell.psd1"

--- a/7Zip4Powershell/PostBuild.targets
+++ b/7Zip4Powershell/PostBuild.targets
@@ -33,8 +33,8 @@
 
     <!-- create nuget package -->
     <Exec
-      WorkingDirectory="$(SolutionDir)"
-      Command=".nuget\NuGet.exe pack 7Zip4Powershell\7Zip4Powershell.nuspec -tool -build -Properties Configuration=$(Configuration) -OutputDirectory $(OutDir) -Version $(GitVersion_MajorMinorPatch)"
+      WorkingDirectory="$(SolutionDir)\7Zip4Powershell"
+      Command="..\.nuget\NuGet.exe pack 7Zip4Powershell.nuspec -tool -build -Properties Configuration=$(Configuration) -OutputDirectory $(OutDir) -Version $(GitVersion_MajorMinorPatch)"
       />
   </Target>
 </Project>

--- a/7Zip4Powershell/PostBuild.targets
+++ b/7Zip4Powershell/PostBuild.targets
@@ -33,7 +33,8 @@
 
     <!-- create nuget package -->
     <Exec
-      Command="$(SolutionDir).nuget\NuGet.exe pack 7Zip4Powershell.nuspec -tool -build -Properties Configuration=$(Configuration) -OutputDirectory $(OutDir) -Version $(GitVersion_MajorMinorPatch)"
+      WorkingDirectory="$(SolutionDir)"
+      Command=".nuget\NuGet.exe pack 7Zip4Powershell.nuspec -tool -build -Properties Configuration=$(Configuration) -OutputDirectory $(OutDir) -Version $(GitVersion_MajorMinorPatch)"
       />
   </Target>
 </Project>


### PR DESCRIPTION
This pull request makes the following changes to the MSBuild targets in `PostBuild.targets`:

* Modify the `<Exec ... />` element to use the `WorkingDirectory` attribute to specify the working directory instead of embedded it inside the `Command` attribute. The `WorkingDirectory` attribute supports spaces in the path while the `Command` attribute does not.
* Modify the `<Target ... />` element to use a `Condition` attribute so it only runs if the `GitVersion_MajorMinorPatch` variable is passed to MSBuild. This allows building the module without creating a Nuget package.