### PR TITLE
Introduced new parameter SkipEmptyDirectories for Compress-7Zip cmdlet.

### DIFF
--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -51,6 +51,9 @@ namespace SevenZip4PowerShell {
         [Parameter(HelpMessage = "Enables encrypting filenames when using the 7z format")]
         public SwitchParameter EncryptFilenames { get; set; }
 
+        [Parameter(HelpMessage = "Disables preservation of empty directories")]
+        public SwitchParameter SkipEmptyDirectories { get; set; }
+
         private OutArchiveFormat _inferredOutArchiveFormat;
 
         protected override void BeginProcessing() {
@@ -129,7 +132,8 @@ namespace SevenZip4PowerShell {
                 var compressor = new SevenZipCompressor {
                     ArchiveFormat = _cmdlet._inferredOutArchiveFormat,
                     CompressionLevel = _cmdlet.CompressionLevel,
-                    CompressionMethod = _cmdlet.CompressionMethod
+                    CompressionMethod = _cmdlet.CompressionMethod,
+                    IncludeEmptyDirectories = !_cmdlet.SkipEmptyDirectories.IsPresent
                 };
 
                 compressor.EncryptHeaders = _cmdlet.EncryptFilenames.IsPresent;


### PR DESCRIPTION
I would like to introduce new switch parameter ` SkipEmptyDirectories ` for `Compress-7Zip` cmdlet. If passed it disables preservation of empty directories in result archive. Underneath it uses `SevenZipCompressor`'s `IncludeEmptyDirectories` option i.e. its negated value is passed as ` IncludeEmptyDirectories` value. Default behavior of course did not changed – empty directories are preserved.