### PR TITLE
Introduced new parameter CompressionMode for Compress-7Zip cmdlet.

### DIFF
--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -43,6 +43,9 @@ namespace SevenZip4PowerShell {
         public CompressionMethod CompressionMethod { get; set; } = CompressionMethod.Default;
 
         [Parameter]
+        public CompressionMode CompressionMode { get; set; } = CompressionMode.Create;
+
+        [Parameter]
         public string Password { get; set; }
 
         [Parameter(HelpMessage = "Allows setting additional parameters on SevenZipCompressor")]
@@ -129,7 +132,8 @@ namespace SevenZip4PowerShell {
                 var compressor = new SevenZipCompressor {
                     ArchiveFormat = _cmdlet._inferredOutArchiveFormat,
                     CompressionLevel = _cmdlet.CompressionLevel,
-                    CompressionMethod = _cmdlet.CompressionMethod
+                    CompressionMethod = _cmdlet.CompressionMethod,
+                    CompressionMode = _cmdlet.CompressionMode
                 };
 
                 compressor.EncryptHeaders = _cmdlet.EncryptFilenames.IsPresent;


### PR DESCRIPTION
I would like to introduce new parameter `CompressionMode` for `Compress-7Zip` cmdlet. It allows expanding existing archives by passing it `Append` value.  Underneath it is just an exposition of `SevenZipCompressor`'s `CompressionMode` option. By default its value is of course `Create`, as it was previously.