### PR TITLE
use secure passwords

### DIFF
--- a/7Zip4Powershell.sln.DotSettings
+++ b/7Zip4Powershell.sln.DotSettings
@@ -1,0 +1,24 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=TinyLittleMvvm/@EntryIndexedValue"></s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=TinyLittleMvvm/@EntryIndexRemoved">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOR/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_FOREACH/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_IFELSE/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_WHILE/@EntryValue">Required</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ACCESSOR_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ACCESSOR_OWNER_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EMPTY_BLOCK_STYLE/@EntryValue">TOGETHER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INVOCABLE_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/OTHER_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ELSE_ON_NEW_LINE/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/TYPE_DECLARATION_BRACES/@EntryValue">END_OF_LINE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForOtherTypes/@EntryValue">UseVarWhenEvident</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/7Zip4Powershell/7Zip4Powershell.csproj
+++ b/7Zip4Powershell/7Zip4Powershell.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Expand7Zip.cs" />
     <Compile Include="Get7Zip.cs" />
     <Compile Include="Get7ZipInformation.cs" />
+    <Compile Include="ParameterSetNames.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ThreadedCmdlet.cs" />
     <Compile Include="Utils.cs" />

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -21,11 +21,6 @@ namespace SevenZip4PowerShell {
     [Cmdlet(VerbsData.Compress, "7Zip")]
     [PublicAPI]
     public class Compress7Zip : ThreadedCmdlet {
-        private static class ParameterSetNames {
-            public const string PlainPassword = "PlainPassword";
-            public const string SecurePassword = "SecurePassword";
-        }
-
         [Parameter(Position = 0, Mandatory = true, HelpMessage = "The full file name of the archive")]
         [ValidateNotNullOrEmpty]
         public string ArchiveFileName { get; set; }
@@ -83,8 +78,7 @@ namespace SevenZip4PowerShell {
 
             _inferredOutArchiveFormat = GetInferredOutArchiveFormat();
 
-            switch (ParameterSetName)
-            {
+            switch (ParameterSetName) {
                 case ParameterSetNames.PlainPassword:
                     _password = Password;
                     break;

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -18,7 +18,7 @@ namespace SevenZip4PowerShell {
         XZ
     }
 
-    [Cmdlet(VerbsData.Compress, "7Zip")]
+    [Cmdlet(VerbsData.Compress, "7Zip", DefaultParameterSetName = ParameterSetNames.NoPassword)]
     [PublicAPI]
     public class Compress7Zip : ThreadedCmdlet {
         [Parameter(Position = 0, Mandatory = true, HelpMessage = "The full file name of the archive")]
@@ -79,6 +79,9 @@ namespace SevenZip4PowerShell {
             _inferredOutArchiveFormat = GetInferredOutArchiveFormat();
 
             switch (ParameterSetName) {
+                case ParameterSetNames.NoPassword:
+                    _password = null;
+                    break;
                 case ParameterSetNames.PlainPassword:
                     _password = Password;
                     break;

--- a/7Zip4Powershell/Expand7Zip.cs
+++ b/7Zip4Powershell/Expand7Zip.cs
@@ -6,7 +6,7 @@ using JetBrains.Annotations;
 using SevenZip;
 
 namespace SevenZip4PowerShell {
-    [Cmdlet(VerbsData.Expand, "7Zip")]
+    [Cmdlet(VerbsData.Expand, "7Zip", DefaultParameterSetName = ParameterSetNames.NoPassword)]
     [PublicAPI]
     public class Expand7Zip : ThreadedCmdlet {
         [Parameter(Position = 0, Mandatory = true, HelpMessage = "The full file name of the archive")]
@@ -32,6 +32,9 @@ namespace SevenZip4PowerShell {
             base.BeginProcessing();
 
             switch (ParameterSetName) {
+                case ParameterSetNames.NoPassword:
+                    _password = null;
+                    break;
                 case ParameterSetNames.PlainPassword:
                     _password = Password;
                     break;

--- a/7Zip4Powershell/Get7Zip.cs
+++ b/7Zip4Powershell/Get7Zip.cs
@@ -1,22 +1,43 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Management.Automation;
+using System.Security;
 using JetBrains.Annotations;
 using SevenZip;
 
 namespace SevenZip4PowerShell {
-    [Cmdlet(VerbsCommon.Get, "7Zip")]
+    [Cmdlet(VerbsCommon.Get, "7Zip", DefaultParameterSetName = ParameterSetNames.NoPassword)]
     [PublicAPI]
     public class Get7Zip : PSCmdlet {
         [Parameter(Position = 0, ValueFromPipeline = true, Mandatory = true, HelpMessage = "The full file name of the archive")]
         [ValidateNotNullOrEmpty]
         public string[] ArchiveFileName { get; set; }
 
-        [Parameter]
+        [Parameter(ParameterSetName = ParameterSetNames.PlainPassword)]
         public string Password { get; set; }
+
+        [Parameter(ParameterSetName = ParameterSetNames.SecurePassword)]
+        public SecureString SecurePassword { get; set; }
+
+        private string _password;
 
         protected override void BeginProcessing() {
             SevenZipBase.SetLibraryPath(Utils.SevenZipLibraryPath);
+
+            switch (ParameterSetName) {
+                case ParameterSetNames.NoPassword:
+                    _password = null;
+                    break;
+                case ParameterSetNames.PlainPassword:
+                    _password = Password;
+                    break;
+                case ParameterSetNames.SecurePassword:
+                    _password = Utils.SecureStringToString(SecurePassword);
+                    break;
+                default:
+                    throw new Exception($"Unsupported parameter set {ParameterSetName}");
+            }
         }
 
         protected override void ProcessRecord() {
@@ -25,8 +46,8 @@ namespace SevenZip4PowerShell {
                 WriteVerbose($"Getting archive data {archiveFileName}");
 
                 SevenZipExtractor extractor;
-                if (!string.IsNullOrEmpty(Password)) {
-                    extractor = new SevenZipExtractor(archiveFileName, Password);
+                if (!string.IsNullOrEmpty(_password)) {
+                    extractor = new SevenZipExtractor(archiveFileName, _password);
                 } else {
                     extractor = new SevenZipExtractor(archiveFileName);
                 }

--- a/7Zip4Powershell/Get7ZipInformation.cs
+++ b/7Zip4Powershell/Get7ZipInformation.cs
@@ -46,8 +46,8 @@ namespace SevenZip4PowerShell {
                 WriteVerbose($"Getting archive data {archiveFileName}");
 
                 SevenZipExtractor extractor;
-                if (!string.IsNullOrEmpty(Password)) {
-                    extractor = new SevenZipExtractor(archiveFileName, Password);
+                if (!string.IsNullOrEmpty(_password)) {
+                    extractor = new SevenZipExtractor(archiveFileName, _password);
                 } else {
                     extractor = new SevenZipExtractor(archiveFileName);
                 }

--- a/7Zip4Powershell/ParameterSetNames.cs
+++ b/7Zip4Powershell/ParameterSetNames.cs
@@ -1,0 +1,6 @@
+namespace SevenZip4PowerShell {
+    internal static class ParameterSetNames {
+        public const string PlainPassword = "PlainPassword";
+        public const string SecurePassword = "SecurePassword";
+    }
+}

--- a/7Zip4Powershell/ParameterSetNames.cs
+++ b/7Zip4Powershell/ParameterSetNames.cs
@@ -1,5 +1,6 @@
 namespace SevenZip4PowerShell {
     internal static class ParameterSetNames {
+        public const string NoPassword = "NoPassword";
         public const string PlainPassword = "PlainPassword";
         public const string SecurePassword = "SecurePassword";
     }

--- a/7Zip4Powershell/Utils.cs
+++ b/7Zip4Powershell/Utils.cs
@@ -1,14 +1,25 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Security;
 
-namespace SevenZip4PowerShell
-{
-    internal class Utils
-    {
+namespace SevenZip4PowerShell {
+    internal static class Utils {
         public static string SevenZipLibraryPath => Path.Combine(AssemblyPath, SevenZipLibraryName);
 
         private static string AssemblyPath => Path.GetDirectoryName(typeof(Utils).Assembly.Location);
 
         private static string SevenZipLibraryName => Environment.Is64BitProcess ? "7z64.dll" : "7z.dll";
+
+        public static string SecureStringToString(SecureString value) {
+            var valuePtr = IntPtr.Zero;
+            try {
+                valuePtr = Marshal.SecureStringToGlobalAllocUnicode(value);
+                return Marshal.PtrToStringUni(valuePtr);
+            }
+            finally {
+                Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
+            }
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The syntax is simple as this:
 Expand-7Zip
     [-ArchiveFileName] <string> 
     [-TargetPath] <string>  
-    [-Password <string>]
+    [-Password <string>] | [-SecurePassword <securestring>]
     [-CustomInitialization <ScriptBlock>]
     [<CommonParameters>]
 
@@ -23,7 +23,7 @@ Compress-7Zip
     [-Format <OutputFormat> {Auto | SevenZip | Zip | GZip | BZip2 | Tar | XZ}] 
     [-CompressionLevel <CompressionLevel> {None | Fast | Low | Normal | High | Ultra}] 
     [-CompressionMethod <CompressionMethod> {Copy | Deflate | Deflate64 | BZip2 | Lzma | Lzma2 | Ppmd | Default}]
-    [-Password <string>]
+    [-Password <string>] | [-SecurePassword <securestring>]
     [-CustomInitialization <ScriptBlock>]
     [-EncryptFilenames]
     [-VolumeSize <int>]
@@ -35,12 +35,12 @@ Compress-7Zip
 
 Get-7Zip
     [-ArchiveFileName] <string[]>
-    [-Password <string>]
+    [-Password <string>] | [-SecurePassword <securestring>]
     [<CommonParameters>]
 
 Get-7ZipInformation
     [-ArchiveFileName] <string[]> 
-    [-Password <string>]
+    [-Password <string>] | [-SecurePassword <securestring>]
     [<CommonParameters>]
 ```
 


### PR DESCRIPTION
This PR enables users to use a `SecureString` for the password. All cmdlets get an additional parameter `SecurePassword`, which can be used instead of `Password` (different parameter set names prevent using both parameters the same time).

This fixes #34.