### PR TITLE
Replace SevenZipSharp.Net45 with Squid-Box.SevenZipSharp library

### DIFF
--- a/7Zip4Powershell/7Zip4Powershell.csproj
+++ b/7Zip4Powershell/7Zip4Powershell.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\WindowsPowerShell\3.0\System.Management.Automation.dll</HintPath>
+    <Reference Include="System.Management.Automation">
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\WindowsPowerShell\3.0\System.Management.Automation.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
   </ItemGroup>
 
@@ -32,7 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="SevenZipSharp.Net45" Version="1.0.19" />
+    <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.2.265" />
     <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -30,7 +30,7 @@ namespace SevenZip4PowerShell {
         public string Path { get; set; }
 
         [Parameter(Position = 2, Mandatory = false, HelpMessage = "The filter to be applied if Path points to a directory")]
-        public string Filter { get; set; }
+        public string Filter { get; set; } = "*";
 
         private List<string> _directoryOrFilesFromPipeline;
 
@@ -217,13 +217,13 @@ namespace SevenZip4PowerShell {
                         if (HasPassword) {
                             compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, _cmdlet._password, _cmdlet.Filter, recursion);
                         } else {
-                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, _cmdlet.Filter, recursion);
+                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, null, _cmdlet.Filter, recursion);
                         }
                     } else {
                         if (HasPassword) {
-                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, recursion, _cmdlet._password);
+                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, _cmdlet._password, null, recursion);
                         } else {
-                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, recursion);
+                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, null, null, recursion);
                         }
                     }
                 }

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -64,6 +64,9 @@ namespace SevenZip4PowerShell {
         [Parameter(HelpMessage = "Disables preservation of empty directories")]
         public SwitchParameter SkipEmptyDirectories { get; set; }
 
+        [Parameter(HelpMessage = "Preserves directory root")]
+        public SwitchParameter PreserveDirectoryRoot { get; set; }
+
         [Parameter(HelpMessage = "Disables recursive files search")]
         public SwitchParameter DisableRecursion { get; set; }
 
@@ -168,6 +171,7 @@ namespace SevenZip4PowerShell {
                     EncryptHeaders = _cmdlet.EncryptFilenames.IsPresent,
                     DirectoryStructure = !_cmdlet.FlattenDirectoryStructure.IsPresent,
                     IncludeEmptyDirectories = !_cmdlet.SkipEmptyDirectories.IsPresent,
+                    PreserveDirectoryRoot = _cmdlet.PreserveDirectoryRoot.IsPresent,
                     CompressionMode = _cmdlet.Append.IsPresent ? CompressionMode.Append : CompressionMode.Create
                 };
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Compress-7Zip
     [-SkipEmptyDirectories]
     [-DisableRecursion]
     [-Append]
+    [-PreserveDirectoryRoot]
     [<CommonParameters>]
 
 Get-7Zip
@@ -83,6 +84,11 @@ Compress-7Zip -Path . -ArchiveFileName demo.7z -CustomInitialization $initScript
 A list of all custom parameters can be found [here](https://sevenzip.osdn.jp/chm/cmdline/switches/method.htm).
 
 ## Changelog
+
+### vNext
+
+* Replaces *SevenZipSharp.Net45* with *Squid-Box.SevenZipSharp* library.
+ ([#57](https://github.com/thoemmi/7Zip4Powershell/pull/57), contributed by [@kborowinski](https://github.com/kborowinski))
 
 ### [v1.10](https://github.com/thoemmi/7Zip4Powershell/releases/tag/v1.10)
 


### PR DESCRIPTION
The [**SevenZipSharp.Net45**](https://github.com/tomap/SevenZipSharp) project is *dead now* and is replaced by actively maintained [**Squid-Box.SevenZipSharp**](https://github.com/squid-box/SevenZipSharp). 

@thoemmi Since the bug in *Squid-Box.SevenZipSharp* where a UNC destination path would fail extraction is fixed now I have decided to reopen PR #55 (point 2)

*Edit:*
Added new switch to preserve directory root when compressing folders
