### PR TITLE
[Enhancement] Added new a parameter OutputPath for Compress-7Zip

### DIFF
--- a/7Zip4Powershell/7Zip4Powershell.csproj
+++ b/7Zip4Powershell/7Zip4Powershell.csproj
@@ -22,6 +22,9 @@
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Libs\System.Management.Automation.dll</HintPath>
+    <Reference Include="System.Management.Automation">
+      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\WindowsPowerShell\3.0\System.Management.Automation.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
   </ItemGroup>
 
@@ -33,6 +36,8 @@
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
     <PackageReference Include="SevenZipSharp.Net45" Version="1.0.19" />
+    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
+    <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.2.265" />
     <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/7Zip4Powershell/7Zip4Powershell.csproj
+++ b/7Zip4Powershell/7Zip4Powershell.csproj
@@ -25,6 +25,9 @@
     <Reference Include="System.Management.Automation">
       <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\WindowsPowerShell\3.0\System.Management.Automation.dll</HintPath>
       <SpecificVersion>false</SpecificVersion>
+    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Libs\System.Management.Automation.dll</HintPath>
     </Reference>
   </ItemGroup>
 
@@ -38,6 +41,8 @@
     <PackageReference Include="SevenZipSharp.Net45" Version="1.0.19" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.2.265" />
+    <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
+    <PackageReference Include="SevenZipSharp.Net45" Version="1.0.19" />
     <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/7Zip4Powershell/7Zip4Powershell.csproj
+++ b/7Zip4Powershell/7Zip4Powershell.csproj
@@ -22,12 +22,6 @@
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Libs\System.Management.Automation.dll</HintPath>
-    <Reference Include="System.Management.Automation">
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\WindowsPowerShell\3.0\System.Management.Automation.dll</HintPath>
-      <SpecificVersion>false</SpecificVersion>
-    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libs\System.Management.Automation.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/7Zip4Powershell/7Zip4Powershell.csproj
+++ b/7Zip4Powershell/7Zip4Powershell.csproj
@@ -21,17 +21,17 @@
   <ItemGroup>
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\WindowsPowerShell\3.0\System.Management.Automation.dll</HintPath>
+      <HintPath>..\Libs\System.Management.Automation.dll</HintPath>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="GitVersionTask">
-      <Version>5.2.4</Version>
+      <Version>5.3.4</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
+    <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
     <PackageReference Include="SevenZipSharp.Net45" Version="1.0.19" />
     <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -67,6 +67,9 @@ namespace SevenZip4PowerShell {
         [Parameter(HelpMessage = "Disables preservation of empty directories")]
         public SwitchParameter SkipEmptyDirectories { get; set; }
 
+        [Parameter(HelpMessage = "Preserves directory root")]
+        public SwitchParameter PreserveDirectoryRoot { get; set; }
+
         [Parameter(HelpMessage = "Disables recursive files search")]
         public SwitchParameter DisableRecursion { get; set; }
 
@@ -171,6 +174,7 @@ namespace SevenZip4PowerShell {
                     EncryptHeaders = _cmdlet.EncryptFilenames.IsPresent,
                     DirectoryStructure = !_cmdlet.FlattenDirectoryStructure.IsPresent,
                     IncludeEmptyDirectories = !_cmdlet.SkipEmptyDirectories.IsPresent,
+                    PreserveDirectoryRoot = _cmdlet.PreserveDirectoryRoot.IsPresent,
                     CompressionMode = _cmdlet.Append.IsPresent ? CompressionMode.Append : CompressionMode.Create
                 };
 

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -187,14 +187,20 @@ namespace SevenZip4PowerShell {
                 }
 
                 // Final path for the archive
-                var outputPath = !string.IsNullOrEmpty(_cmdlet.OutputPath) ? _cmdlet.OutputPath : _cmdlet.SessionState.Path.CurrentFileSystemLocation.Path;
+                var outputPath = !string.IsNullOrEmpty(_cmdlet.OutputPath) 
+                    ? _cmdlet.OutputPath 
+                    : _cmdlet.SessionState.Path.CurrentFileSystemLocation.Path;
+
                 // Check whether the output path is a path to the file
                 // The folder and file name cannot be the same in the same folder
-                if (File.Exists(outputPath))
+                if (File.Exists(outputPath)) {
                     throw new ArgumentException("The output path is a file, not a directory");
+                }
+
                 // If the directory doesn't exist, create it
-                if (!Directory.Exists(outputPath))
+                if (!Directory.Exists(outputPath)) {
                     Directory.CreateDirectory(outputPath);
+                }
 
                 var directoryOrFiles = _cmdlet._directoryOrFilesFromPipeline
                                                                         // Don't put outputPath here, it will break the relative path

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -184,6 +184,14 @@ namespace SevenZip4PowerShell {
 
                 // Final path for the archive
                 var outputPath = !string.IsNullOrEmpty(_cmdlet.OutputPath) ? _cmdlet.OutputPath : _cmdlet.SessionState.Path.CurrentFileSystemLocation.Path;
+                // Check whether the output path is a path to the file
+                // The folder and file name cannot be the same in the same folder
+                if (File.Exists(outputPath))
+                    throw new ArgumentException("The output path is a file, not a directory");
+                // If the directory doesn't exist, create it
+                if (!Directory.Exists(outputPath))
+                    Directory.CreateDirectory(outputPath);
+
                 var directoryOrFiles = _cmdlet._directoryOrFilesFromPipeline
                                                                         // Don't put outputPath here, it will break the relative path
                     .Select(path => new FileInfo(System.IO.Path.Combine(_cmdlet.SessionState.Path.CurrentFileSystemLocation.Path, path)).FullName).ToArray();

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -32,6 +32,9 @@ namespace SevenZip4PowerShell {
         [Parameter(Position = 2, Mandatory = false, HelpMessage = "The filter to be applied if Path points to a directory")]
         public string Filter { get; set; }
 
+        [Parameter(HelpMessage = "Output path for a compressed archive")]
+        public string OutputPath { get; set; }
+
         private List<string> _directoryOrFilesFromPipeline;
 
         [Parameter]
@@ -179,9 +182,11 @@ namespace SevenZip4PowerShell {
                     };
                 }
 
+                // Final path for the archive
+                var outputPath = !string.IsNullOrEmpty(_cmdlet.OutputPath) ? _cmdlet.OutputPath : _cmdlet.SessionState.Path.CurrentFileSystemLocation.Path;
                 var directoryOrFiles = _cmdlet._directoryOrFilesFromPipeline
-                    .Select(path => new FileInfo(System.IO.Path.Combine(_cmdlet.SessionState.Path.CurrentFileSystemLocation.Path, path)).FullName).ToArray();
-                var archiveFileName = new FileInfo(System.IO.Path.Combine(_cmdlet.SessionState.Path.CurrentFileSystemLocation.Path, _cmdlet.ArchiveFileName)).FullName;
+                    .Select(path => new FileInfo(System.IO.Path.Combine(outputPath, path)).FullName).ToArray();
+                var archiveFileName = new FileInfo(System.IO.Path.Combine(outputPath, _cmdlet.ArchiveFileName)).FullName;
 
                 var activity = directoryOrFiles.Length > 1
                     ? $"Compressing {directoryOrFiles.Length} Files to {archiveFileName}"

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -185,7 +185,8 @@ namespace SevenZip4PowerShell {
                 // Final path for the archive
                 var outputPath = !string.IsNullOrEmpty(_cmdlet.OutputPath) ? _cmdlet.OutputPath : _cmdlet.SessionState.Path.CurrentFileSystemLocation.Path;
                 var directoryOrFiles = _cmdlet._directoryOrFilesFromPipeline
-                    .Select(path => new FileInfo(System.IO.Path.Combine(outputPath, path)).FullName).ToArray();
+                                                                        // Don't put outputPath here, it will break the relative path
+                    .Select(path => new FileInfo(System.IO.Path.Combine(_cmdlet.SessionState.Path.CurrentFileSystemLocation.Path, path)).FullName).ToArray();
                 var archiveFileName = new FileInfo(System.IO.Path.Combine(outputPath, _cmdlet.ArchiveFileName)).FullName;
 
                 var activity = directoryOrFiles.Length > 1

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -30,7 +30,7 @@ namespace SevenZip4PowerShell {
         public string Path { get; set; }
 
         [Parameter(Position = 2, Mandatory = false, HelpMessage = "The filter to be applied if Path points to a directory")]
-        public string Filter { get; set; }
+        public string Filter { get; set; } = "*";
 
         [Parameter(HelpMessage = "Output path for a compressed archive")]
         public string OutputPath { get; set; }
@@ -231,13 +231,13 @@ namespace SevenZip4PowerShell {
                         if (HasPassword) {
                             compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, _cmdlet._password, _cmdlet.Filter, recursion);
                         } else {
-                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, _cmdlet.Filter, recursion);
+                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, null, _cmdlet.Filter, recursion);
                         }
                     } else {
                         if (HasPassword) {
-                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, recursion, _cmdlet._password);
+                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, _cmdlet._password, null, recursion);
                         } else {
-                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, recursion);
+                            compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, null, null, recursion);
                         }
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Compress-7Zip
     [-SkipEmptyDirectories]
     [-DisableRecursion]
     [-Append]
+    [-PreserveDirectoryRoot]
     [<CommonParameters>]
 
 Get-7Zip
@@ -83,6 +84,11 @@ Compress-7Zip -Path . -ArchiveFileName demo.7z -CustomInitialization $initScript
 A list of all custom parameters can be found [here](https://sevenzip.osdn.jp/chm/cmdline/switches/method.htm).
 
 ## Changelog
+
+### vNext
+
+* Replaces *SevenZipSharp.Net45* with *Squid-Box.SevenZipSharp* library.
+ ([#57](https://github.com/thoemmi/7Zip4Powershell/pull/57), contributed by [@kborowinski](https://github.com/kborowinski))
 
 ### [v1.10](https://github.com/thoemmi/7Zip4Powershell/releases/tag/v1.10)
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ A list of all custom parameters can be found [here](https://sevenzip.osdn.jp/chm
 ### vNext
 
 * Replaces *SevenZipSharp.Net45* with *Squid-Box.SevenZipSharp* library.
- ([#57](https://github.com/thoemmi/7Zip4Powershell/pull/57), contributed by [@kborowinski](https://github.com/kborowinski))
+  ([#57](https://github.com/thoemmi/7Zip4Powershell/pull/57), contributed by [@kborowinski](https://github.com/kborowinski))
+* Adds new a parameter `OutputPath` for `Compress-7Zip`
+  ([#60](https://github.com/thoemmi/7Zip4Powershell/pull/60), contributed by [@iRebbok](https://github.com/iRebbok))
 
 ### [v1.10](https://github.com/thoemmi/7Zip4Powershell/releases/tag/v1.10)
 


### PR DESCRIPTION
### Content:
- Added the `System.Management.Automation` dependency to the repository.
- Added the `OutputPath` parameter for `Compress-7Zip`.

#### Why does this make sense?
- Native support for a different archive output path allows you to call a script in a third-party folder and not process the archive output path.

P.S: I need this for my CI, I call the script from the repository folder and want to not process the output file of the archive in addition.