### PR TITLE
[Fix] Absolute paths in the `ArchiveFileName`

### DIFF
--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -203,13 +203,13 @@ namespace SevenZip4PowerShell {
                 }
 
                 var directoryOrFiles = _cmdlet._directoryOrFilesFromPipeline
-                                                                        // Don't put outputPath here, it will break the relative path
-                    .Select(path => new FileInfo(System.IO.Path.Combine(_cmdlet.SessionState.Path.CurrentFileSystemLocation.Path, path)).FullName).ToArray();
-                var archiveFileName = new FileInfo(System.IO.Path.Combine(outputPath, _cmdlet.ArchiveFileName)).FullName;
+                    // Don't put outputPath here, it will break the relative path
+                    .Select(System.IO.Path.GetFullPath).ToArray();
+                var archiveFileName = System.IO.Path.GetFullPath(System.IO.Path.Combine(outputPath, System.IO.Path.GetFileName(_cmdlet.ArchiveFileName)));
 
                 var activity = directoryOrFiles.Length > 1
                     ? $"Compressing {directoryOrFiles.Length} Files to {archiveFileName}"
-                    : $"Compressing {directoryOrFiles.First()} to {archiveFileName}";
+                    : $"Compressing {directoryOrFiles[0]} to {archiveFileName}";
 
                 var currentStatus = "Compressing";
                 compressor.FilesFound += (sender, args) =>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Powershell module for creating and extracting 7-Zip archives supporting Powershe
 > of other users find my package helpful.
 >
 > I really appreciated if you report issues or suggest new feature. However,
-> I don't use this package myself anymore, and I don't have the time to 
+> I don't use this package myself anymore, and I don't have the time to
 > maintain it appropriately. So please don't expect me to fix any bugs. Any Pull
 > Request is welcome though.
 
@@ -21,17 +21,18 @@ The syntax is simple as this:
 
 ```powershell
 Expand-7Zip
-    [-ArchiveFileName] <string> 
-    [-TargetPath] <string>  
+    [-ArchiveFileName] <string>
+    [-TargetPath] <string>
     [-Password <string>] | [-SecurePassword <securestring>]
     [<CommonParameters>]
 
 Compress-7Zip
-    [-ArchiveFileName] <string> 
-    [-Path] <string> 
-    [[-Filter] <string>] 
-    [-Format <OutputFormat> {Auto | SevenZip | Zip | GZip | BZip2 | Tar | XZ}] 
-    [-CompressionLevel <CompressionLevel> {None | Fast | Low | Normal | High | Ultra}] 
+    [-ArchiveFileName] <string>
+    [-Path] <string>
+    [[-Filter] <string>]
+    [-OutputPath] <string>
+    [-Format <OutputFormat> {Auto | SevenZip | Zip | GZip | BZip2 | Tar | XZ}]
+    [-CompressionLevel <CompressionLevel> {None | Fast | Low | Normal | High | Ultra}]
     [-CompressionMethod <CompressionMethod> {Copy | Deflate | Deflate64 | BZip2 | Lzma | Lzma2 | Ppmd | Default}]
     [-Password <string>] | [-SecurePassword <securestring>]
     [-CustomInitialization <ScriptBlock>]
@@ -50,7 +51,7 @@ Get-7Zip
     [<CommonParameters>]
 
 Get-7ZipInformation
-    [-ArchiveFileName] <string[]> 
+    [-ArchiveFileName] <string[]>
     [-Password <string>] | [-SecurePassword <securestring>]
     [<CommonParameters>]
 ```
@@ -87,7 +88,7 @@ A list of all custom parameters can be found [here](https://sevenzip.osdn.jp/chm
 
 ### [v1.12](https://github.com/thoemmi/7Zip4Powershell/releases/tag/v1.12)
 
-* Uses PowerShell 5 reference assembly, which reduces the package size dramatically 
+* Uses PowerShell 5 reference assembly, which reduces the package size dramatically
   ([#61](https://github.com/thoemmi/7Zip4Powershell/pull/61), contributed by [@kborowinski](https://github.com/kborowinski))
 
 ### [v1.11](https://github.com/thoemmi/7Zip4Powershell/releases/tag/v1.11)
@@ -153,13 +154,13 @@ May 29, 2016
 30 March, 2016
 
 * Added `Password` parameter to both `Compress-7Zip` and `Expand-7Zip` (#8)
-  
+
 ## Motivation
 
 I've written and maintaining the module just for fun and to serve my own needs. If
-it's useful for you too, that's great. I don't demand anything in return. 
+it's useful for you too, that's great. I don't demand anything in return.
 
-However, if you like this module and feel the urge to give something back, a coffee 
+However, if you like this module and feel the urge to give something back, a coffee
 or a beer is always appreciated. Thank you very much in advance.
 
 [![PayPal.me](https://img.shields.io/badge/PayPal-me-blue.svg?maxAge=2592000)](https://www.paypal.me/ThomasFreudenberg)


### PR DESCRIPTION
I fixed such a thing as an absolute path in the `ArchiveFileName`, it didn't work correctly with the `OutputPath`, because `System.IO.Path.Combine` doesn't expect an absolute path not in the first argument, as written in MSDN:
> This method assumes that the first argument is an absolute path and that the following argument or arguments are relative paths. If this is not the case, and particularly if any subsequent arguments are strings input by the user, call the `Join` or `TryJoin` method instead.

But in Net Framework 4.6.1 there is no such method and I replaced it with `System.IO.Path.GetFileName`, so we get only the name of the file and combine it with the `OutputPath`.

I also added `OutputPath` to README.

