### PR TITLE
Upgrade Framework version to .NET Standard 2.0

### DIFF
--- a/7Zip4Powershell/7Zip4Powershell.csproj
+++ b/7Zip4Powershell/7Zip4Powershell.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-    <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
     <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.3.283" />
   </ItemGroup>
 </Project>

--- a/publish.ps1
+++ b/publish.ps1
@@ -22,7 +22,7 @@ if (Test-Path $moduleTargetPath) {
 New-Item $moduleTargetPath -ItemType Directory | Out-Null
 
 # copy all required files to that folder
-Copy-Item -Path (Join-Path $PSScriptRoot "7Zip4Powershell" "bin" $configuration "net461" "*.*") -Exclude "JetBrains.Annotations.dll" -Destination $moduleTargetPath
+Copy-Item -Path (Join-Path $PSScriptRoot "7Zip4Powershell" "bin" $configuration "netstandard2.0" "*.*") -Exclude "JetBrains.Annotations.dll" -Destination $moduleTargetPath
 
 # determine the version
 $versionInfo = (Get-Command (Join-Path $moduleTargetPath "7Zip4PowerShell.dll")).FileVersionInfo


### PR DESCRIPTION
Upgrades the framework version to allow this module to be used with the newest versions of PowerShell, including PowerShell Core 6+ and PowerShell 7.

* Fixes #68 
* Tested with Windows PowerShell 5.1 and PowerShell 7