### PR TITLE
Path is now a List of Strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ _ReSharper*
 [Oo]bj
 
 *.nupkg
-/.vs
+# /.vs* as opposed to /.vs will ingore both Visual Studio as well as Visual Studio Code/Codium
+/.vs*  
 /Module


### PR DESCRIPTION
Fixes #53 

As I had the need to be able to add both files and Directories in
a script I'm running, I made these changes to this Module. Now
I thought I would share them with the repo.

Please let me know if I need to add anything more to this.

In a gist: I Changed how the Execute function searches and adds files to
the list of files to compress. this also meant I had to reimplement the
the Filter and DisableRecursion Options as well.

- Adding in gitignore to also ignore vs code folders.
- Adding functionality to list multiple files/folders to Path parameter
- Reworking Filter to apply to all directories listed in
  Path CLI-Parameter
- Reworking the Recursive search to apply to the new file-search routine