### PR TITLE
Workaround for NullReferenceException when extracting multiple 7zip archives simultaneously on PS 7.4.0

### DIFF
--- a/7Zip4Powershell/7Zip4Powershell.csproj
+++ b/7Zip4Powershell/7Zip4Powershell.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Squid-Box.SevenZipSharp" Version="1.6.1.23" />
   </ItemGroup>

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -30,7 +30,6 @@ namespace SevenZip4PowerShell {
         public string Path { get; set; }
 
         [Parameter(Position = 2, Mandatory = false, HelpMessage = "The filter to be applied if Path points to a directory")]
-        //public string Filter { get; set; } = "*";
         public string Filter { get; set; }
 
         [Parameter(HelpMessage = "Output path for a compressed archive")]

--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -260,15 +260,12 @@ namespace SevenZip4PowerShell {
                     } else {
                         compressor.CompressFiles(archiveFileName, directoryOrFiles);
                     }
-                }
-                if (directoryOrFiles.Any(path => new DirectoryInfo(path).Exists)) {
+                } else if (directoryOrFiles.Any(path => new DirectoryInfo(path).Exists)) {
                     if (directoryOrFiles.Length > 1) {
                         throw new ArgumentException("Only one directory allowed as input");
                     }
-
                     var recursion = !_cmdlet.DisableRecursion.IsPresent;
                     var filter = string.IsNullOrWhiteSpace(_cmdlet.Filter) ? "*" : _cmdlet.Filter;
-
                     if (HasPassword) {
                         compressor.CompressDirectory(directoryOrFiles[0], archiveFileName, _cmdlet._password, filter, recursion);
                     } else {

--- a/7Zip4Powershell/Expand7Zip.cs
+++ b/7Zip4Powershell/Expand7Zip.cs
@@ -68,7 +68,7 @@ namespace SevenZip4PowerShell {
                 Write($"Extracting archive \"{archiveFileName}\"");
 
                 // Reuse ProgressRecord instance insead of creating new one on each progress update
-                Progress = new ProgressRecord(Environment.CurrentManagedThreadId, activity, statusDescription) { PercentComplete = 0};
+                Progress = new ProgressRecord(Environment.CurrentManagedThreadId, activity, statusDescription) { PercentComplete = 0 };
 
                 using (var extractor = CreateExtractor(archiveFileName)) {
                     extractor.Extracting += (sender, args) => {

--- a/7Zip4Powershell/ThreadedCmdlet.cs
+++ b/7Zip4Powershell/ThreadedCmdlet.cs
@@ -40,7 +40,7 @@ namespace SevenZip4PowerShell {
                 worker.Progress.RecordType = ProgressRecordType.Completed;
                 WriteProgress(worker.Progress);
             } catch (NullReferenceException) {
-                // Possible race condition on PowerShell 7.4.0 where null reference exception is thrown when completing ProgressPane
+                // Possible bug in PowerShell 7.4.0 leading to a null reference exception being thrown on ProgressPane completion
                 // This is not happening on PowerShell 5.1
             }
         }

--- a/7Zip4Powershell/ThreadedCmdlet.cs
+++ b/7Zip4Powershell/ThreadedCmdlet.cs
@@ -48,7 +48,7 @@ namespace SevenZip4PowerShell {
                 try {
                     worker.Execute();
                 } catch (Exception ex) {
-					worker.Queue.Add(new ErrorRecord(ex, "7Zip4PowerShellException", ErrorCategory.NotSpecified, worker));
+                    worker.Queue.Add(new ErrorRecord(ex, "7Zip4PowerShellException", ErrorCategory.NotSpecified, worker));
                 }
                 finally {
                     worker.Queue.CompleteAdding();

--- a/7Zip4Powershell/ThreadedCmdlet.cs
+++ b/7Zip4Powershell/ThreadedCmdlet.cs
@@ -35,11 +35,13 @@ namespace SevenZip4PowerShell {
 
             _thread.Join();
 
-            // In case of worker thread exception hide the remaining progress pane
-            if (!worker.IsCompleted)
-            {
+            try {
+                worker.Progress.StatusDescription = "Finished";
                 worker.Progress.RecordType = ProgressRecordType.Completed;
                 WriteProgress(worker.Progress);
+            } catch (NullReferenceException) {
+                // Possible race condition on PowerShell 7.4.0 where null reference exception is thrown when completing ProgressPane
+                // This is not happening on PowerShell 5.1
             }
         }
 
@@ -65,8 +67,6 @@ namespace SevenZip4PowerShell {
 
     public abstract class CmdletWorker {
         public BlockingCollection<object> Queue { get; set; }
-
-        public bool IsCompleted { get; set; } = false;
 
         public ProgressRecord Progress { get; set; }
 


### PR DESCRIPTION
@thoemmi  This is *workaround* for issue #88. I'll report this issue on PowerShell repository but in the meantime I have implemented this fix to make *7Zip4PowerShell* behave reliably on PS 7.4.0. I have also made small `Filter` code refactoring for simplification. And I have also enclosed all progress pane paths in double quotes. When you have a time, please make this a beta release for testing *(I did test it myself but better be safe than sorry)*