### PR TITLE
Remove NRE workaround and implement progress completion via event handlers

### DIFF
--- a/7Zip4Powershell/Compress7Zip.cs
+++ b/7Zip4Powershell/Compress7Zip.cs
@@ -253,10 +253,14 @@ namespace SevenZip4PowerShell {
                     Progress.PercentComplete = args.PercentDone;
                     WriteProgress(Progress);
                 };
-
                 compressor.FileCompressionStarted += (sender, args) => {
                     currentStatus = $"Compressing {args.FileName}";
                     Write($"Compressing \"{args.FileName}\"");
+                };
+                compressor.CompressionFinished += (sender, args) => {
+                    Progress.StatusDescription = "Finished";
+                    Progress.RecordType = ProgressRecordType.Completed;
+                    WriteProgress(Progress);
                 };
 
                 if (directoryOrFiles.Any(path => new FileInfo(path).Exists)) {

--- a/7Zip4Powershell/Expand7Zip.cs
+++ b/7Zip4Powershell/Expand7Zip.cs
@@ -75,10 +75,14 @@ namespace SevenZip4PowerShell {
                         Progress.PercentComplete = args.PercentDone;
                         WriteProgress(Progress);
                     };
-
                     extractor.FileExtractionStarted += (sender, args) => {
                         statusDescription = $"Extracting file \"{args.FileInfo.FileName}\"";
                         Write(statusDescription);
+                    };
+                    extractor.ExtractionFinished += (sender, args) => {
+                        Progress.StatusDescription = "Finished";
+                        Progress.RecordType = ProgressRecordType.Completed;
+                        WriteProgress(Progress);
                     };
                     extractor.ExtractArchive(targetPath);
                 }

--- a/7Zip4Powershell/ThreadedCmdlet.cs
+++ b/7Zip4Powershell/ThreadedCmdlet.cs
@@ -34,15 +34,6 @@ namespace SevenZip4PowerShell {
             }
 
             _thread.Join();
-
-            try {
-                worker.Progress.StatusDescription = "Finished";
-                worker.Progress.RecordType = ProgressRecordType.Completed;
-                WriteProgress(worker.Progress);
-            } catch (NullReferenceException) {
-                // Possible bug in PowerShell 7.4.0 leading to a null reference exception being thrown on ProgressPane completion
-                // This is not happening on PowerShell 5.1
-            }
         }
 
         private static Thread StartBackgroundThread(CmdletWorker worker) {


### PR DESCRIPTION
@thoemmi 
1. Use `ExtractionFinished` and `CompressionFinished` event handlers to properly complete the progress bar instance
2. Remove the workaround for #88:
	- The cause of this issue has been identified and a [PR](https://github.com/PowerShell/PowerShell/pull/24911) is in the approval process. The issue was caused by race conditions where multiple threads attempted to write to the console simultaneously, leading to `NullReferenceExceptions`. The PR introduces additional locking mechanisms to prevent such occurrences and ensure thread-safe console access.