### PR TITLE
Fix release notes losing newlines/content in GitHub Release and PS Gallery

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -76,6 +76,7 @@ jobs:
           -f tag_name=${{ github.ref_name }} `
           --jq '.body'
         if ([string]::IsNullOrWhiteSpace($notes)) { throw "Release notes generation returned empty content" }
+        $notes | Out-File -FilePath "release-notes.md" -Encoding utf8
         $delimiter = [System.Guid]::NewGuid().ToString()
         "notes<<$delimiter`n$notes`n$delimiter" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       env:
@@ -92,5 +93,5 @@ jobs:
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        body: ${{ steps.release_notes.outputs.notes }}
+        body_path: release-notes.md
         

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -68,7 +68,6 @@ jobs:
         path: Module/7Zip4Powershell
 
     - name: Generate Release Notes
-      id: release_notes
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
@@ -77,18 +76,16 @@ jobs:
           --jq '.body'
         if ([string]::IsNullOrWhiteSpace($notes)) { throw "Release notes generation returned empty content" }
         $notes | Out-File -FilePath "release-notes.md" -Encoding utf8
-        $delimiter = [System.Guid]::NewGuid().ToString()
-        "notes<<$delimiter`n$notes`n$delimiter" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       env:
         GH_TOKEN: ${{ github.token }}
 
     - name: Publish to PowerShell Gallery
       shell: pwsh
       run: |
-        Publish-Module -Path (Join-Path $env:GITHUB_WORKSPACE "Module" "7Zip4Powershell") -NuGetApiKey $env:NUGET_API_KEY -ReleaseNotes $env:RELEASE_NOTES
+        $releaseNotes = Get-Content -Path "release-notes.md" -Raw
+        Publish-Module -Path (Join-Path $env:GITHUB_WORKSPACE "Module" "7Zip4Powershell") -NuGetApiKey $env:NUGET_API_KEY -ReleaseNotes $releaseNotes
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        RELEASE_NOTES: ${{ steps.release_notes.outputs.notes }}
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -82,7 +82,9 @@ jobs:
     - name: Publish to PowerShell Gallery
       shell: pwsh
       run: |
-        $releaseNotes = Get-Content -Path "release-notes.md" -Raw
+        $ErrorActionPreference = 'Stop'
+        $releaseNotes = Get-Content -Path "release-notes.md" -Raw -ErrorAction Stop
+        if ([string]::IsNullOrWhiteSpace($releaseNotes)) { throw "Release notes file 'release-notes.md' is empty or whitespace-only" }
         Publish-Module -Path (Join-Path $env:GITHUB_WORKSPACE "Module" "7Zip4Powershell") -NuGetApiKey $env:NUGET_API_KEY -ReleaseNotes $releaseNotes
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
## Problem

When using template expressions inline in YAML, GitHub Actions substitutes the multiline string before YAML parsing:

- **`body:`** in `with:` block: newlines are collapsed - release description appears as a single line (observed in v2.10 release)
- **`RELEASE_NOTES:`** in `env:` block: multiline value produces invalid YAML - env var is empty - PS Gallery release notes are empty

## Fix

Write the generated notes to `release-notes.md` once, then read from it in both steps:

- `softprops/action-gh-release` uses `body_path: release-notes.md` instead of `body:`
- `Publish-Module` reads `Get-Content -Path release-notes.md -Raw` instead of the env var

The now-unnecessary GITHUB_OUTPUT heredoc (step output) is also removed.